### PR TITLE
Replace postgresql role

### DIFF
--- a/configurations/example.yaml
+++ b/configurations/example.yaml
@@ -178,7 +178,11 @@ postgresql_metrics_enabled: true
 postgresql_persistence_enabled: false
 postgresql_persistence_size: 2Gi
 ## Scaling settings
-postgresql_replicas: 1
+postgresql_replicas: 2
+## pgpool settings
+pgpool_admin_user: pgpool
+pgpool_admin_password:
+pgpool_replicas: 1
 
 # prometheus configuration
 ## Application settings

--- a/roles/administration/pgadmin/templates/values.yaml
+++ b/roles/administration/pgadmin/templates/values.yaml
@@ -14,7 +14,7 @@ serverDefinitions:
       "Group": "Servers",
       "Port": 5432,
       "Username": "postgres",
-      "Host": "postgresql.datastore.svc.cluster.local",
+      "Host": "postgresql-pgpool.datastore.svc.cluster.local",
       "SSLMode": "prefer",
       "MaintenanceDB": "postgres"
     }

--- a/roles/automation/rundeck/defaults/main.yaml
+++ b/roles/automation/rundeck/defaults/main.yaml
@@ -10,7 +10,7 @@ chart_name: rundeck
 chart_version: 0.3.4
 
 # Main configuration
-rundeck_database_host: postgresql.datastore.svc.cluster.local
+rundeck_database_host: postgresql-pgpool.datastore.svc.cluster.local
 rundeck_database_name: rundeck
 rundeck_database_user: rundeck
 rundeck_database_password:

--- a/roles/communication/mattermost/defaults/main.yaml
+++ b/roles/communication/mattermost/defaults/main.yaml
@@ -10,7 +10,7 @@ chart_name: mattermost-team-edition
 chart_version: 3.19.0
 
 # Main configuration
-mattermost_database_host: postgresql.datastore.svc.cluster.local
+mattermost_database_host: postgresql-pgpool.datastore.svc.cluster.local
 mattermost_database_name: mattermost
 mattermost_database_user: mattermost
 mattermost_database_password:

--- a/roles/datastore/postgresql/defaults/main.yaml
+++ b/roles/datastore/postgresql/defaults/main.yaml
@@ -6,18 +6,22 @@ release_namespace: datastore
 
 # Chart information
 chart_repository: https://charts.bitnami.com/bitnami
-chart_name: postgresql
-chart_version: 10.2.0
+chart_name: postgresql-ha
+chart_version: 6.3.3
 
-# Main configuration
+# PostgreSQL configuration
 postgresql_admin_user: postgres
 postgresql_admin_password:
-postgresql_config_max_connections: 64
-postgresql_config_shared_libraries: pgaudit,pg_stat_statements
+postgresql_config_max_connections: 32
+postgresql_config_shared_libraries: pgaudit,pg_stat_statements,repmgr
 postgresql_metrics_enabled: true
 postgresql_persistence_enabled: false
 postgresql_persistence_size: 2Gi
-postgresql_replicas: 1
-postgresql_replication_enabled: false
 postgresql_replication_user: replicator
 postgresql_replication_password:
+postgresql_replicas: 2
+
+# pgpool configuration
+pgpool_admin_user: pgpool
+pgpool_admin_password:
+pgpool_replicas: 1

--- a/roles/datastore/postgresql/templates/secrets.yaml
+++ b/roles/datastore/postgresql/templates/secrets.yaml
@@ -1,4 +1,3 @@
-#jinja2:lstrip_blocks: True
 ---
 apiVersion: v1
 kind: Secret
@@ -8,6 +7,4 @@ metadata:
 type: Opaque
 data:
   postgresql-password: "{{ postgresql_admin_password | b64encode }}"
-  {% if postgresql_replication_enabled %}
-  postgresql-replication-password: "{{ postgresql_replication_password | b64encode }}"
-  {% endif %}
+  repmgr-password: "{{ postgresql_replication_password | b64encode }}"

--- a/roles/datastore/postgresql/templates/values.yaml
+++ b/roles/datastore/postgresql/templates/values.yaml
@@ -2,38 +2,49 @@
 ---
 
 fullnameOverride: "{{ release_name }}"
+clusterDomain: "{{ cluster_domain }}"
 
-{% if postgresql_replication_enabled %}
-replication:
+postgresql:
+  replicaCount: "{{ postgresql_replicas }}"
+
+  username: postgres
+  database: postgres
+  existingSecret: postgresql-credentials
+
+  repmgrUsername: "{{ postgresql_replication_user }}"
+
+  sharedPreloadLibraries: "{{ postgresql_config_shared_libraries }}"
+  maxConnections: "{{ postgresql_config_max_connections }}"
+
+  initdbScripts:
+    init_databases.sql: |
+    {% for variable in (lookup('varnames', '.+_database_name$')).split(',') %}
+      {% set component = variable.split('_')[0] %}
+      create role {{ vars[component + '_database_user'] }} with login encrypted password '{{ vars[component + '_database_password'] }}';
+      create database {{ component }} with owner {{ vars[component + '_database_user'] }};
+    {% endfor %}
+
+pgpool:
+  customUsers:
+    {% set pgpool_users, pgpool_passwords = [], [] %}
+    {% for variable in (lookup('varnames', '.+_database_name$')).split(',') %}
+      {% set component = variable.split('_')[0] %}
+      {% if pgpool_users.append(vars[component + '_database_user']) %}{% endif %}
+      {% if pgpool_passwords.append(vars[component + '_database_password']) %}{% endif %}
+    {% endfor %}
+    usernames: "{{ pgpool_users | join(';') }}"
+    passwords: "{{ pgpool_passwords | join(';') }}"
+
+  replicaCount: "{{ pgpool_replicas }}"
+  adminUsername: "{{ pgpool_admin_user }}"
+  adminPassword: "{{ pgpool_admin_password }}"
+
+volumePermissions:
   enabled: true
-  user: "{{ postgresql_replication_user }}"
-  password: "{{ postgresql_replication_password }}"
-  readReplicas: {{ postgresql_replicas }}
-  applicationName: postgres
-{% endif %}
 
-postgresqlUsername: "{{ postgresql_admin_user }}"
-existingSecret: postgresql-credentials
-usePasswordFile: true
-postgresqlDatabase: postgres
-
-initdbScripts:
-  init_databases.sql: |
-  {% for variable in (lookup('varnames', '.+_database_name$')).split(',') %}
-    {% set component = variable.split('_')[0] %}
-    create role {{ vars[component + '_database_user'] }} with login encrypted password '{{ vars[component + '_database_password'] }}';
-    create database {{ component }} with owner {{ vars[component + '_database_user'] }};
-  {% endfor %}
-
-initdbUser: "{{ postgresql_admin_user }}"
-initdbPassword: "{{ postgresql_admin_password }}"
-
-postgresqlSharedPreloadLibraries: "{{ postgresql_config_shared_libraries }}"
-postgresqlMaxConnections: "{{ postgresql_config_max_connections }}"
+metrics:
+  enabled: "{{ postgresql_metrics_enabled }}"
 
 persistence:
   enabled: "{{ postgresql_persistence_enabled }}"
   size: "{{ postgresql_persistence_size }}"
-
-metrics:
-  enabled: {{ postgresql_metrics_enabled }}

--- a/roles/monitoring/grafana/defaults/main.yaml
+++ b/roles/monitoring/grafana/defaults/main.yaml
@@ -13,7 +13,7 @@ chart_version: 6.1.16
 grafana_admin_user: admin
 grafana_admin_password: grafana
 grafana_database_enabled: false
-grafana_database_host: postgresql.datastore.svc.cluster.local
+grafana_database_host: postgresql-pgpool.datastore.svc.cluster.local
 grafana_database_name: grafana
 grafana_database_user:
 grafana_database_password:

--- a/roles/monitoring/grafana/templates/values.yaml
+++ b/roles/monitoring/grafana/templates/values.yaml
@@ -56,7 +56,7 @@ datasources:
       {% if components.postgresql.enabled %}
       - name: PostgreSQL
         type: postgres
-        url: postgresql.datastore.svc.cluster.local
+        url: postgresql-pgpool.datastore.svc.cluster.local
         database: "{{ grafana_database_name }}"
         user: "{{ grafana_database_user }}"
         secureJsonData:


### PR DESCRIPTION
## Description

Replacing the bitnami/postgresql chart with bitnami/postgresql-ha in order to have an HA cluster with pgpool/repmgr.

## Changes

### Added

- Added pgpool settings to the example configuration.

### Changed

- Replaced the service used by other roles to connect to PostgreSQL.
- Updated the default configuration for the postgresql role.
- Updated the templates (secrets and values) for the postgresql role.

---
Resolves #40 
