### PR TITLE
Update charts

### DIFF
--- a/roles/automation/rundeck/defaults/main.yaml
+++ b/roles/automation/rundeck/defaults/main.yaml
@@ -5,7 +5,7 @@ release_name: rundeck
 release_namespace: automation
 
 # Chart information
-chart_repository: http://storage.googleapis.com/kubernetes-charts-incubator
+chart_repository: https://www.dwardu.com/helm-charts
 chart_name: rundeck
 chart_version: 0.3.4
 

--- a/roles/datastore/redis/defaults/main.yaml
+++ b/roles/datastore/redis/defaults/main.yaml
@@ -7,7 +7,7 @@ release_namespace: datastore
 # Chart information
 chart_repository: https://charts.bitnami.com/bitnami
 chart_name: redis
-chart_version: 12.2.3
+chart_version: 12.2.4
 
 # Main configuration
 redis_master_set: master

--- a/roles/ingress/ingress-nginx/defaults/main.yaml
+++ b/roles/ingress/ingress-nginx/defaults/main.yaml
@@ -7,7 +7,7 @@ release_namespace: kube-system
 # Chart information
 chart_repository: https://kubernetes.github.io/ingress-nginx
 chart_name: ingress-nginx
-chart_version: 3.15.2
+chart_version: 3.16.1
 
 # Main configuration
 ingress_nginx_autoscaling_enabled: false

--- a/roles/messaging/rabbitmq/defaults/main.yaml
+++ b/roles/messaging/rabbitmq/defaults/main.yaml
@@ -7,7 +7,7 @@ release_namespace: messaging
 # Chart information
 chart_repository: https://charts.bitnami.com/bitnami
 chart_name: rabbitmq
-chart_version: 8.6.0
+chart_version: 8.6.1
 
 # Main configuration
 rabbitmq_admin_user: admin

--- a/roles/monitoring/prometheus/defaults/main.yaml
+++ b/roles/monitoring/prometheus/defaults/main.yaml
@@ -7,7 +7,7 @@ release_namespace: monitoring
 # Chart information
 chart_repository: https://prometheus-community.github.io/helm-charts
 chart_name: prometheus
-chart_version: 13.0.0
+chart_version: 13.0.1
 
 # Main configuration
 alertmanager_persistence_enabled: false


### PR DESCRIPTION
## Description

Updating some of the charts to their latest versions.

## Changes

### Changed

- Replaced the helm repository for rundeck (which was still using the incubator repository).
- Updated the following charts:
  - ingress-nginx
  - prometheus
  - rabbitmq
  - redis


